### PR TITLE
feat(components): add reusable SearchBar component

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -1,0 +1,47 @@
+// components/SearchBar.js
+// Reusable search input with icon
+
+import React from 'react';
+import { View, TextInput, Text, StyleSheet } from 'react-native';
+import { Colors } from '../constants/colors';
+
+export default function SearchBar({ placeholder, value, onChangeText }) {
+    return (
+        <View style={styles.container}>
+            <Text style={styles.icon}>🔍</Text>
+            <TextInput
+                style={styles.input}
+                placeholder={placeholder}
+                placeholderTextColor={Colors.textLight}
+                value={value}
+                onChangeText={onChangeText}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        backgroundColor: Colors.white,
+        borderRadius: 12,
+        paddingHorizontal: 15,
+        paddingVertical: 12,
+        flexDirection: 'row',
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.08,
+        shadowRadius: 3,
+        elevation: 1,
+    },
+    icon: {
+        fontSize: 20,
+        marginRight: 10,
+    },
+    input: {
+        flex: 1,
+        fontSize: 16,
+        color: Colors.textPrimary,
+        padding: 0, // Override default Android padding
+    },
+});


### PR DESCRIPTION
## What
Created a new reusable `SearchBar` component in `components/SearchBar.js`.

## Why
- The existing `HomeScreen` uses a fake search bar (a `<Text>` instead of an actual input)
- The upcoming `SearchScreen` needs a working search input
- Following the DRY principle, both screens should share the same component

## Component API
```jsx
<SearchBar
  placeholder="Rechercher un médecin..."
  value={text}
  onChangeText={setText}
/>
```

## Implementation details
- Uses React Native's native `TextInput` component
- Styles defined with `StyleSheet.create()`
- Search icon hardcoded (UX consistency across the app)
- Controlled component pattern (parent owns the state)
- Android padding fix applied (`padding: 0` on TextInput)

## Testing
- [x] Manually tested by temporarily integrating into HomeScreen
- [x] User can type into the input
- [x] Placeholder displays when empty
- [x] Visual matches existing search bar in HomeScreen

## Out of scope
- ❌ Integration into HomeScreen and SearchScreen (separate tasks)
- ❌ Unit tests (to be added in a dedicated PR)

## Related
Closes #3