### PR TITLE
feat(screens): build MessagesScreen with empty state

### DIFF
--- a/screens/MessagesScreen.js
+++ b/screens/MessagesScreen.js
@@ -1,19 +1,76 @@
 // screens/MessagesScreen.js
-// Écran de la messagerie patient-médecin
+// Patient messaging screen (currently empty state)
 
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 import { Colors } from '../constants/colors';
 
 export default function MessagesScreen() {
     return (
-        <View style={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            backgroundColor: Colors.background,
-        }}>
-            <Text style={{ color: Colors.textPrimary }}>Messages</Text>
+        <View style={styles.screen}>
+            {/* HEADER */}
+            <View style={styles.header}>
+                <Text style={styles.headerTitle}>Messages</Text>
+            </View>
+
+            {/* EMPTY STATE */}
+            <View style={styles.emptyState}>
+                <Text style={styles.emptyIcon}>💬</Text>
+                <Text style={styles.emptyTitle}>Aucun message</Text>
+                <Text style={styles.emptyText}>
+                    Vous n'avez pas encore de conversation avec vos praticiens
+                </Text>
+            </View>
         </View>
     );
 }
+
+const styles = StyleSheet.create({
+    // Layout
+    screen: {
+        flex: 1,
+        backgroundColor: Colors.background,
+    },
+
+    // Header
+    header: {
+        backgroundColor: Colors.white,
+        paddingHorizontal: 20,
+        paddingTop: 50,
+        paddingBottom: 16,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.08,
+        shadowRadius: 3,
+        elevation: 2,
+    },
+    headerTitle: {
+        fontSize: 28,
+        fontWeight: 'bold',
+        color: Colors.textPrimary,
+    },
+
+    // Empty state
+    emptyState: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingHorizontal: 40,
+    },
+    emptyIcon: {
+        fontSize: 64,
+        marginBottom: 16,
+    },
+    emptyTitle: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        color: Colors.textPrimary,
+        marginBottom: 8,
+    },
+    emptyText: {
+        fontSize: 14,
+        color: Colors.textSecondary,
+        textAlign: 'center',
+        lineHeight: 20,
+    },
+});


### PR DESCRIPTION
## What
Built the `MessagesScreen` with a proper empty state matching the HTML mockup.

## Why
The screen was a placeholder. The messaging feature isn't ready yet, so we display a clean empty state until it's implemented.

## What changed
- ✅ Header with "Messages" title (consistent with `AppointmentsScreen`)
- ✅ Empty state UI with:
  - 💬 Large emoji icon
  - Bold title "Aucun message"
  - Centered description text
- ✅ All styles using `StyleSheet.create()`
- ✅ All colors from `Colors` constants

## Testing
- [x] Manual visual test on Android (Expo Go)
- [x] Header displays correctly
- [x] Empty state is centered both horizontally and vertically
- [x] No console errors

## Out of scope
- ❌ Real messaging feature (separate issue)
- ❌ Unit tests (will be added in dedicated test PR tomorrow)

## Related
Closes #6