### PR TITLE
ci: add SonarCloud code quality scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # .github/workflows/ci.yml
 # Continuous Integration workflow
-# Runs lint and format checks on every push and pull request
+# Runs lint, format and code quality checks on every push and pull request
 
 name: CI
 
@@ -64,3 +64,23 @@ jobs:
 
       - name: Run Prettier check
         run: npm run format:check
+
+  # ─────────────────────────────────────────
+  # Job 3: SonarCloud code quality scan
+  # ─────────────────────────────────────────
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # SonarCloud needs full git history for accurate blame & new code detection
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+# === Project Identity ===
+sonar.projectKey=samehmiissaoui_MedAppMobile
+sonar.organization=samehmiissaoui
+
+# === Project Metadata ===
+sonar.projectName=MedAppMobile
+sonar.projectVersion=1.0
+
+# === Source Code ===
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+
+# === Exclusions ===
+sonar.exclusions=node_modules/**,**/*.test.js,**/*.spec.js,coverage/**,.expo/**,android/**,ios/**,scripts/**,babel.config.js,metro.config.js


### PR DESCRIPTION
## What

Setup SonarCloud code quality analysis integrated with the GitHub Actions CI pipeline.

## Why

- Catch bugs, vulnerabilities and code smells beyond ESLint
- Enforce "Clean as You Code" principle on new code
- Quality Gate as PR status check (will block merge if quality drops)
- Public SonarCloud badge → professional signal on the GitHub repo

## What changed

- Added `sonar-project.properties` at repo root with project key, organization and exclusions
- Added new `sonarcloud` job in `.github/workflows/ci.yml` running in parallel with `lint` and `format`
- Disabled SonarCloud Automatic Analysis (using CI-driven scan only — single source of truth)
- Token `SONAR_TOKEN` stored as GitHub repository secret

## Testing

- ✅ Lint job: green
- ✅ Format check job: green
- ✅ SonarCloud job: green (48s)
- ✅ First scan completed on `feature/16-setup-sonarcloud` branch
- ✅ Dashboard accessible at https://sonarcloud.io/project/overview?id=samehmiissaoui_MedAppMobile

## Out of scope

- Coverage configuration → will be addressed when Jest is reinstated (issue #5)
- Migration from deprecated `sonarcloud-github-action` to `sonarqube-scan-action` → follow-up
- Promote `develop` as SonarCloud Main Branch → follow-up after merge
- Update long-lived branches pattern → follow-up after merge
- README badge → follow-up


Closes #16