### PR TITLE
docs: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,40 @@
+---
+name: Bug
+about: Report a bug or unexpected behavior
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- Clear and concise description of the bug -->
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behavior
+
+<!-- What should happen -->
+
+## Actual behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- Device: <!-- e.g., iPhone 14, Pixel 7, Web Chrome -->
+- OS: <!-- e.g., iOS 17.2, Android 14, Windows 11 -->
+- App version: <!-- e.g., 1.0.0 -->
+
+## Screenshots / Logs
+
+<!-- If applicable, add screenshots or error logs -->
+
+## Additional context
+
+<!-- Anything else relevant -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+---
+name: Feature
+about: Propose a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## What
+
+<!-- Brief description of the feature -->
+
+## Why
+
+<!-- Business or technical motivation. Why does this matter? -->
+
+## Tasks
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Acceptance Criteria
+
+- ✅ Criterion 1
+- ✅ Criterion 2
+
+## Out of scope
+
+<!-- What this feature explicitly does NOT cover -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What
+
+<!-- Brief description of the changes -->
+
+## Why
+
+<!-- Motivation: what problem does this solve? -->
+
+## What changed
+
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+
+- [ ] Lint passes locally (`npm run lint`)
+- [ ] Format check passes locally (`npm run format:check`)
+- [ ] CI green (Lint + Format + SonarCloud)
+- [ ] Manual testing performed
+
+## Out of scope
+
+<!-- What this PR explicitly does NOT include -->
+
+Closes #


### PR DESCRIPTION
## What

Add structured templates for GitHub issues and pull requests.

## Why

- Enforce consistent format across all issues and PRs
- Reduce friction (no more manual copy-paste of conventions)
- Improve reviewer experience (scannable structure)
- Onboard future contributors with clear guidelines

## What changed

- Created `.github/ISSUE_TEMPLATE/feature.md` — template for new features (auto-labels `enhancement`)
- Created `.github/ISSUE_TEMPLATE/bug.md` — template for bug reports (auto-labels `bug`, prefixes title with `[BUG]`)
- Created `.github/PULL_REQUEST_TEMPLATE.md` — auto-fills PR description with What/Why/What changed/Testing/Out of scope sections

## Testing

- ✅ Lint passes locally
- ✅ Format check passes locally (Prettier auto-formatted the templates)
- ✅ CI green expected (no JS/JSX changes)
- ✅ Will verify "New issue" picker and PR auto-fill after merge

## Out of scope

- Custom GitHub Discussions templates
- Auto-labeling logic beyond what's in the front matter
- Config file `.github/ISSUE_TEMPLATE/config.yml` for advanced picker (follow-up if needed)


Closes #18